### PR TITLE
Fix docs for clone and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ curl -L https://foundry.paradigm.xyz | bash && foundryup
 ```
 
 ```bash
-git clone https://github.com/elizaos/jeju.git && cd jeju
+git clone https://github.com/jejunetwork/jeju.git && cd jeju
 bun install
 ```
 

--- a/apps/documentation/docs/pages/packages/cli.mdx
+++ b/apps/documentation/docs/pages/packages/cli.mdx
@@ -63,9 +63,9 @@ jeju keys distributed -n mainnet # Multi-TEE ceremony
 ## From Monorepo
 
 ```bash
-bun run jeju:dev
-bun run jeju:test
-bun run jeju:deploy
+bun run dev
+bun run test
+bun run deploy
 ```
 
 ## Environment

--- a/apps/gateway/README.md
+++ b/apps/gateway/README.md
@@ -69,7 +69,7 @@ Server runs on http://localhost:4001
 
 ```bash
 # Unit tests
-bun test:unit
+bun run test:unit
 
 # E2E tests
 bun run test:e2e

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -6,17 +6,17 @@ Blockchain data indexer powered by Subsquid. Provides GraphQL API for blocks, tr
 
 ```bash
 cd apps/indexer
-npm install
+bun install
 ```
 
 ## Run
 
 ```bash
 # Start PostgreSQL
-npm run db:up
+bun run db:up
 
 # Start indexer
-npm run dev
+bun run dev
 ```
 
 GraphQL API on http://localhost:4350/graphql
@@ -25,7 +25,7 @@ GraphQL API on http://localhost:4350/graphql
 
 ```bash
 # All tests
-npm run test
+bun run test
 
 # GraphQL queries
 ./test/verify-all-queries.sh

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -123,9 +123,9 @@ jeju deploy testnet --dry-run
 ## Monorepo
 
 ```bash
-bun run jeju:dev
-bun run jeju:test
-bun run jeju:deploy
+bun run dev
+bun run test
+bun run deploy
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Fix root README clone URL to jejunetwork/jeju
- Align indexer README commands with Bun scripts
- Fix gateway unit test command typo
- Update monorepo CLI docs for correct script names

## Testing
- Not run (docs-only changes)