### PR TITLE
Require signed auth for feed writes

### DIFF
--- a/apps/factory/api/routes/feed.ts
+++ b/apps/factory/api/routes/feed.ts
@@ -3,6 +3,7 @@ import { Elysia, t } from 'elysia'
 import type { Address, Hex } from 'viem'
 import { CreateCastBodySchema, expectValid } from '../schemas'
 import * as farcasterService from '../services/farcaster'
+import { requireAuth } from '../validation/access-control'
 
 const CastReactionBodySchema = t.Object({
   castHash: t.String({ minLength: 3 }),
@@ -42,14 +43,16 @@ function getPagination(query: { cursor?: string; limit?: string }) {
   }
 }
 
-function requireWalletAddress(
+async function requireSignedAddress(
   headers: Record<string, string | undefined>,
-): Address {
-  const address = headers['x-wallet-address'] as Address | undefined
-  if (!address) {
-    throw new Error('UNAUTHORIZED')
+  set: { status?: number },
+): Promise<Address | null> {
+  const authResult = await requireAuth(headers)
+  if (!authResult.success) {
+    set.status = 401
+    return null
   }
-  return address
+  return authResult.address
 }
 
 export const feedRoutes = new Elysia({ prefix: '/api/feed' })
@@ -139,13 +142,10 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
   .post(
     '/',
     async ({ body, headers, set }) => {
-      let address: Address
-      try {
-        address = requireWalletAddress(headers)
-      } catch {
-        set.status = 401
+      const address = await requireSignedAddress(headers, set)
+      if (!address) {
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
         }
       }
 
@@ -190,13 +190,10 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
   .delete(
     '/:castHash',
     async ({ params, headers, set }) => {
-      let address: Address
-      try {
-        address = requireWalletAddress(headers)
-      } catch {
-        set.status = 401
+      const address = await requireSignedAddress(headers, set)
+      if (!address) {
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
         }
       }
 
@@ -216,13 +213,10 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
   .post(
     '/like',
     async ({ body, headers, set }) => {
-      let address: Address
-      try {
-        address = requireWalletAddress(headers)
-      } catch {
-        set.status = 401
+      const address = await requireSignedAddress(headers, set)
+      if (!address) {
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
         }
       }
 
@@ -246,13 +240,10 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
   .delete(
     '/like',
     async ({ body, headers, set }) => {
-      let address: Address
-      try {
-        address = requireWalletAddress(headers)
-      } catch {
-        set.status = 401
+      const address = await requireSignedAddress(headers, set)
+      if (!address) {
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
         }
       }
 
@@ -276,13 +267,10 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
   .post(
     '/recast',
     async ({ body, headers, set }) => {
-      let address: Address
-      try {
-        address = requireWalletAddress(headers)
-      } catch {
-        set.status = 401
+      const address = await requireSignedAddress(headers, set)
+      if (!address) {
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
         }
       }
 
@@ -306,13 +294,10 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
   .delete(
     '/recast',
     async ({ body, headers, set }) => {
-      let address: Address
-      try {
-        address = requireWalletAddress(headers)
-      } catch {
-        set.status = 401
+      const address = await requireSignedAddress(headers, set)
+      if (!address) {
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
         }
       }
 
@@ -355,13 +340,10 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
   .post(
     '/follow/:fid',
     async ({ params, headers, set }) => {
-      let address: Address
-      try {
-        address = requireWalletAddress(headers)
-      } catch {
-        set.status = 401
+      const address = await requireSignedAddress(headers, set)
+      if (!address) {
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
         }
       }
 
@@ -381,13 +363,10 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
   .delete(
     '/follow/:fid',
     async ({ params, headers, set }) => {
-      let address: Address
-      try {
-        address = requireWalletAddress(headers)
-      } catch {
-        set.status = 401
+      const address = await requireSignedAddress(headers, set)
+      if (!address) {
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: 'Authentication required' },
         }
       }
 

--- a/apps/factory/web/hooks/useFarcaster.ts
+++ b/apps/factory/web/hooks/useFarcaster.ts
@@ -1,6 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useAccount } from 'wagmi'
-import { API_BASE, apiDelete, apiFetch, apiPost, getHeaders } from '../lib/api'
+import { useAccount, useSignMessage } from 'wagmi'
+import {
+  API_BASE,
+  apiDeleteSigned,
+  apiFetch,
+  apiPost,
+  apiPostSigned,
+  getHeaders,
+} from '../lib/api'
 
 export interface FarcasterUser {
   fid: number
@@ -249,6 +256,7 @@ export function useTrendingFeed() {
 
 export function usePublishCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
@@ -257,78 +265,89 @@ export function usePublishCast() {
       channelId?: string
       parentHash?: string
       embeds?: Array<{ url: string }>
-    }) => apiPost('/api/feed', params, address),
+    }) => apiPostSigned('/api/feed', params, address, signMessageAsync),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useDeleteCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (castHash: string) =>
-      apiDelete(`/api/feed/${castHash}`, undefined, address),
+      apiDeleteSigned(
+        `/api/feed/${castHash}`,
+        undefined,
+        address,
+        signMessageAsync,
+      ),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useLikeCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (params: { castHash: string; castFid: number }) =>
-      apiPost('/api/feed/like', params, address),
+      apiPostSigned('/api/feed/like', params, address, signMessageAsync),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useUnlikeCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (params: { castHash: string; castFid: number }) =>
-      apiDelete('/api/feed/like', params, address),
+      apiDeleteSigned('/api/feed/like', params, address, signMessageAsync),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useRecastCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (params: { castHash: string; castFid: number }) =>
-      apiPost('/api/feed/recast', params, address),
+      apiPostSigned('/api/feed/recast', params, address, signMessageAsync),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useUnrecastCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (params: { castHash: string; castFid: number }) =>
-      apiDelete('/api/feed/recast', params, address),
+      apiDeleteSigned('/api/feed/recast', params, address, signMessageAsync),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useFollowUser() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (targetFid: number) => {
-      const response = await fetch(`${API_BASE}/api/feed/follow/${targetFid}`, {
-        method: 'POST',
-        headers: getHeaders(address),
-      })
-      return response.json()
-    },
+    mutationFn: (targetFid: number) =>
+      apiPostSigned(
+        `/api/feed/follow/${targetFid}`,
+        {},
+        address,
+        signMessageAsync,
+      ),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ['farcaster', 'user'] }),
   })
@@ -336,16 +355,17 @@ export function useFollowUser() {
 
 export function useUnfollowUser() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (targetFid: number) => {
-      const response = await fetch(`${API_BASE}/api/feed/follow/${targetFid}`, {
-        method: 'DELETE',
-        headers: getHeaders(address),
-      })
-      return response.json()
-    },
+    mutationFn: (targetFid: number) =>
+      apiDeleteSigned(
+        `/api/feed/follow/${targetFid}`,
+        undefined,
+        address,
+        signMessageAsync,
+      ),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ['farcaster', 'user'] }),
   })

--- a/apps/factory/web/lib/api.ts
+++ b/apps/factory/web/lib/api.ts
@@ -8,6 +8,8 @@ import { FACTORY_API_URL } from '../config/env'
 
 export const API_BASE = FACTORY_API_URL
 
+type SignMessageFn = (args: { message: string }) => Promise<string>
+
 /** Build headers with optional wallet address authentication */
 export function getHeaders(address?: string): Record<string, string> {
   const headers: Record<string, string> = {}
@@ -16,6 +18,35 @@ export function getHeaders(address?: string): Record<string, string> {
     headers.authorization = `Bearer ${address}`
   }
   return headers
+}
+
+function generateNonce(bytes: number = 16): string {
+  const buffer = new Uint8Array(bytes)
+  crypto.getRandomValues(buffer)
+  return Array.from(buffer)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function buildAuthMessage(timestamp: number, nonce: string): string {
+  return `Factory Auth\nTimestamp: ${timestamp}\nNonce: ${nonce}`
+}
+
+export async function getSignedHeaders(
+  address: string,
+  signMessageAsync: SignMessageFn,
+): Promise<Record<string, string>> {
+  const nonce = generateNonce()
+  const timestamp = Date.now()
+  const message = buildAuthMessage(timestamp, nonce)
+  const signature = await signMessageAsync({ message })
+
+  return {
+    'x-jeju-address': address,
+    'x-jeju-timestamp': String(timestamp),
+    'x-jeju-nonce': nonce,
+    'x-jeju-signature': signature,
+  }
 }
 
 /** Typed fetch wrapper that handles JSON responses */
@@ -66,4 +97,53 @@ export async function apiDelete<T>(
     options.body = JSON.stringify(body)
   }
   return apiFetch<T>(path, options)
+}
+
+/** POST request helper with signed auth headers */
+export async function apiPostSigned<T>(
+  path: string,
+  body: unknown,
+  address: string | undefined,
+  signMessageAsync: SignMessageFn,
+): Promise<T> {
+  if (!address) {
+    throw new Error('Wallet address required')
+  }
+  const signedHeaders = await getSignedHeaders(address, signMessageAsync)
+  const response = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...signedHeaders,
+    },
+    body: JSON.stringify(body),
+  })
+
+  return response.json()
+}
+
+/** DELETE request helper with signed auth headers */
+export async function apiDeleteSigned<T>(
+  path: string,
+  body: unknown | undefined,
+  address: string | undefined,
+  signMessageAsync: SignMessageFn,
+): Promise<T> {
+  if (!address) {
+    throw new Error('Wallet address required')
+  }
+  const signedHeaders = await getSignedHeaders(address, signMessageAsync)
+  const headers: Record<string, string> = { ...signedHeaders }
+  const options: RequestInit = {
+    method: 'DELETE',
+    headers,
+  }
+
+  if (body) {
+    headers['Content-Type'] = 'application/json'
+    options.body = JSON.stringify(body)
+  }
+
+  const response = await fetch(`${API_BASE}${path}`, options)
+  return response.json()
 }


### PR DESCRIPTION
Summary:
- Require signed auth headers for write operations in /api/feed
- Add signed-request helpers in the Factory web API client
- Update Farcaster feed mutations to sign requests before posting

Security:
Previously, clients could spoof x-wallet-address and perform write actions on behalf of another user. This change requires a wallet signature for feed write endpoints.

Testing:
- Not run (auth plumbing changes only)