### PR TITLE
Require signed auth for messages writes

### DIFF
--- a/apps/factory/api/routes/messages.ts
+++ b/apps/factory/api/routes/messages.ts
@@ -7,6 +7,7 @@ import {
   getUser,
   isFarcasterConnected,
 } from '../services/farcaster'
+import { requireAuth } from '../validation/access-control'
 
 const SendMessageBodySchema = t.Object({
   recipientFid: t.Number({ minimum: 1 }),
@@ -277,13 +278,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/',
     async ({ body, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers)
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       if (!(await isFarcasterConnected(address))) {
         set.status = 401
@@ -331,13 +333,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/conversation/:fid/read',
     async ({ params, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers)
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       const recipientFid = parseInt(params.fid, 10)
       await dcService.markConversationAsRead(address, recipientFid)
@@ -357,13 +360,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/conversation/:fid/archive',
     async ({ params, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers)
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       const recipientFid = parseInt(params.fid, 10)
       await dcService.archiveConversation(address, recipientFid)
@@ -383,13 +387,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/conversation/:fid/mute',
     async ({ params, body, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers)
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       const recipientFid = parseInt(params.fid, 10)
       await dcService.setConversationMuted(address, recipientFid, body.muted)
@@ -410,13 +415,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/reconnect',
     async ({ headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers)
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       await dcService.reconnectClient(address)
 
@@ -458,13 +464,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/encryption-key/publish',
     async ({ headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers)
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       await dcService.publishEncryptionKey(address)
 

--- a/apps/factory/web/hooks/useMessages.ts
+++ b/apps/factory/web/hooks/useMessages.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useAccount } from 'wagmi'
-import { API_BASE, apiFetch, apiPost, getHeaders } from '../lib/api'
+import { useAccount, useSignMessage } from 'wagmi'
+import { API_BASE, apiFetch, apiPostSigned, getHeaders } from '../lib/api'
 
 export interface ConversationUser {
   fid: number
@@ -119,6 +119,7 @@ export function useMessages(
 
 export function useSendMessage() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
@@ -127,7 +128,7 @@ export function useSendMessage() {
       text: string
       embeds?: Array<{ url: string }>
       replyTo?: string
-    }) => apiPost('/api/messages', params, address),
+    }) => apiPostSigned('/api/messages', params, address, signMessageAsync),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: ['messages', 'messages', variables.recipientFid],
@@ -140,11 +141,17 @@ export function useSendMessage() {
 
 export function useMarkAsRead() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (recipientFid: number) =>
-      apiPost(`/api/messages/conversation/${recipientFid}/read`, {}, address),
+      apiPostSigned(
+        `/api/messages/conversation/${recipientFid}/read`,
+        {},
+        address,
+        signMessageAsync,
+      ),
     onSuccess: (_, recipientFid) => {
       queryClient.invalidateQueries({
         queryKey: ['messages', 'conversation', recipientFid],
@@ -157,14 +164,16 @@ export function useMarkAsRead() {
 
 export function useArchiveConversation() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (recipientFid: number) =>
-      apiPost(
+      apiPostSigned(
         `/api/messages/conversation/${recipientFid}/archive`,
         {},
         address,
+        signMessageAsync,
       ),
     onSuccess: () =>
       queryClient.invalidateQueries({
@@ -175,14 +184,16 @@ export function useArchiveConversation() {
 
 export function useMuteConversation() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (params: { recipientFid: number; muted: boolean }) =>
-      apiPost(
+      apiPostSigned(
         `/api/messages/conversation/${params.recipientFid}/mute`,
         { muted: params.muted },
         address,
+        signMessageAsync,
       ),
     onSuccess: (_, { recipientFid }) => {
       queryClient.invalidateQueries({
@@ -195,10 +206,12 @@ export function useMuteConversation() {
 
 export function useReconnect() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: () => apiPost('/api/messages/reconnect', {}, address),
+    mutationFn: () =>
+      apiPostSigned('/api/messages/reconnect', {}, address, signMessageAsync),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['messages'] }),
   })
 }
@@ -231,11 +244,17 @@ export function useEncryptionKey() {
 
 export function usePublishEncryptionKey() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: () =>
-      apiPost('/api/messages/encryption-key/publish', {}, address),
+      apiPostSigned(
+        '/api/messages/encryption-key/publish',
+        {},
+        address,
+        signMessageAsync,
+      ),
     onSuccess: () =>
       queryClient.invalidateQueries({
         queryKey: ['messages', 'encryption-key'],


### PR DESCRIPTION
Summary:
- Require signed auth headers for write operations in /api/messages
- Update Factory web messaging mutations to sign requests before posting

Security:
Previously, clients could spoof  and perform write actions (send messages, mark read, archive/mute, publish encryption keys) on behalf of another user. This change requires a wallet signature for message write endpoints.

Testing:
- Not run (auth plumbing changes only)