### PR TITLE
Require signed auth for messages reads

### DIFF
--- a/apps/factory/api/routes/messages.ts
+++ b/apps/factory/api/routes/messages.ts
@@ -7,6 +7,7 @@ import {
   getUser,
   isFarcasterConnected,
 } from '../services/farcaster'
+import { requireAuth } from '../validation/access-control'
 
 const SendMessageBodySchema = t.Object({
   recipientFid: t.Number({ minimum: 1 }),
@@ -30,13 +31,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .get(
     '/',
     async ({ headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers, { skipNonceCheck: true })
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       if (!(await isFarcasterConnected(address))) {
         set.status = 401
@@ -105,13 +107,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .get(
     '/status',
     async ({ headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers, { skipNonceCheck: true })
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       if (!(await isFarcasterConnected(address))) {
         return {
@@ -150,13 +153,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .get(
     '/conversation/:fid',
     async ({ params, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers, { skipNonceCheck: true })
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       if (!(await isFarcasterConnected(address))) {
         set.status = 401
@@ -217,13 +221,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .get(
     '/conversation/:fid/messages',
     async ({ params, query, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers, { skipNonceCheck: true })
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       if (!(await isFarcasterConnected(address))) {
         set.status = 401
@@ -434,13 +439,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .get(
     '/encryption-key',
     async ({ headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers, { skipNonceCheck: true })
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       const publicKey = await dcService.getEncryptionPublicKey(address)
 
@@ -482,13 +488,14 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .get(
     '/search/users',
     async ({ query, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
-      if (!address) {
+      const authResult = await requireAuth(headers, { skipNonceCheck: true })
+      if (!authResult.success) {
         set.status = 401
         return {
-          error: { code: 'UNAUTHORIZED', message: 'Wallet address required' },
+          error: { code: 'UNAUTHORIZED', message: authResult.error },
         }
       }
+      const address = authResult.address
 
       const username = query.q
       if (!username) {

--- a/apps/factory/web/hooks/useMessages.ts
+++ b/apps/factory/web/hooks/useMessages.ts
@@ -1,6 +1,49 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useAccount } from 'wagmi'
+import { useAccount, useSignMessage } from 'wagmi'
 import { API_BASE, apiFetch, apiPost, getHeaders } from '../lib/api'
+
+type SignedReadCache = {
+  address: string
+  timestamp: number
+  signature: string
+  expiresAt: number
+}
+
+let signedReadCache: SignedReadCache | null = null
+
+async function getSignedReadHeaders(
+  address: string,
+  signMessageAsync: (args: { message: string }) => Promise<string>,
+): Promise<Record<string, string>> {
+  const now = Date.now()
+  if (
+    signedReadCache &&
+    signedReadCache.address === address &&
+    signedReadCache.expiresAt > now + 15_000
+  ) {
+    return {
+      'x-jeju-address': signedReadCache.address,
+      'x-jeju-timestamp': String(signedReadCache.timestamp),
+      'x-jeju-signature': signedReadCache.signature,
+    }
+  }
+
+  const timestamp = Date.now()
+  const message = `Factory Auth\nTimestamp: ${timestamp}\nNonce: `
+  const signature = await signMessageAsync({ message })
+  signedReadCache = {
+    address,
+    timestamp,
+    signature,
+    expiresAt: timestamp + 4 * 60 * 1000,
+  }
+
+  return {
+    'x-jeju-address': address,
+    'x-jeju-timestamp': String(timestamp),
+    'x-jeju-signature': signature,
+  }
+}
 
 export interface ConversationUser {
   fid: number
@@ -49,6 +92,7 @@ export interface MessagingStatus {
 
 export function useMessagingStatus() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'status', address],
@@ -56,7 +100,8 @@ export function useMessagingStatus() {
       if (!address) {
         return { connected: false, isInitialized: false, unreadCount: 0 }
       }
-      return apiFetch('/api/messages/status', { address })
+      const headers = await getSignedReadHeaders(address, signMessageAsync)
+      return apiFetch('/api/messages/status', { headers })
     },
     enabled: !!address,
     refetchInterval: 30_000,
@@ -66,11 +111,19 @@ export function useMessagingStatus() {
 
 export function useConversations() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'conversations', address],
-    queryFn: () =>
-      apiFetch<{ conversations: Conversation[] }>('/api/messages', { address }),
+    queryFn: async () => {
+      const headers = await getSignedReadHeaders(
+        address as string,
+        signMessageAsync,
+      )
+      return apiFetch<{ conversations: Conversation[] }>('/api/messages', {
+        headers,
+      })
+    },
     enabled: !!address,
     staleTime: 30_000,
   })
@@ -78,14 +131,19 @@ export function useConversations() {
 
 export function useConversation(recipientFid: number) {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'conversation', recipientFid, address],
-    queryFn: () =>
-      apiFetch<{ conversation: Conversation } | { error: { code: string } }>(
-        `/api/messages/conversation/${recipientFid}`,
-        { address },
-      ),
+    queryFn: async () => {
+      const headers = await getSignedReadHeaders(
+        address as string,
+        signMessageAsync,
+      )
+      return apiFetch<
+        { conversation: Conversation } | { error: { code: string } }
+      >(`/api/messages/conversation/${recipientFid}`, { headers })
+    },
     enabled: !!address && !!recipientFid,
     staleTime: 30_000,
   })
@@ -96,6 +154,7 @@ export function useMessages(
   options?: { before?: string; after?: string; limit?: number },
 ) {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'messages', recipientFid, options, address],
@@ -105,9 +164,13 @@ export function useMessages(
       if (options?.after) params.set('after', options.after)
       if (options?.limit) params.set('limit', String(options.limit))
 
+      const signedHeaders = await getSignedReadHeaders(
+        address as string,
+        signMessageAsync,
+      )
       const response = await fetch(
         `${API_BASE}/api/messages/conversation/${recipientFid}/messages?${params}`,
-        { headers: getHeaders(address) },
+        { headers: { ...getHeaders(address), ...signedHeaders } },
       )
       return response.json()
     },
@@ -205,14 +268,20 @@ export function useReconnect() {
 
 export function useSearchUsers(query: string) {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'search', query, address],
-    queryFn: () =>
-      apiFetch<{ users: ConversationUser[] }>(
+    queryFn: async () => {
+      const headers = await getSignedReadHeaders(
+        address as string,
+        signMessageAsync,
+      )
+      return apiFetch<{ users: ConversationUser[] }>(
         `/api/messages/search/users?q=${encodeURIComponent(query)}`,
-        { address },
-      ),
+        { headers },
+      )
+    },
     enabled: !!address && query.length >= 2,
     staleTime: 60_000,
   })
@@ -220,10 +289,17 @@ export function useSearchUsers(query: string) {
 
 export function useEncryptionKey() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'encryption-key', address],
-    queryFn: () => apiFetch('/api/messages/encryption-key', { address }),
+    queryFn: async () => {
+      const headers = await getSignedReadHeaders(
+        address as string,
+        signMessageAsync,
+      )
+      return apiFetch('/api/messages/encryption-key', { headers })
+    },
     enabled: !!address,
     staleTime: 300_000,
   })


### PR DESCRIPTION
Summary:
- Require signed auth for read endpoints in /api/messages (skip nonce check)
- Sign read requests in the Factory web client with a cached 4‑minute signature

Security:
Previously, a client could spoof x-wallet-address to read other users' conversations and message metadata. This change requires a wallet signature for message reads.

UX:
Read requests reuse a signed header for ~4 minutes to avoid repeated wallet prompts.

Testing:
- Not run (auth plumbing changes only)