### PR TITLE
Require signed auth for Factory feed and messages

### DIFF
--- a/apps/factory/api/routes/feed.ts
+++ b/apps/factory/api/routes/feed.ts
@@ -3,6 +3,7 @@ import { Elysia, t } from 'elysia'
 import type { Address, Hex } from 'viem'
 import { CreateCastBodySchema, expectValid } from '../schemas'
 import * as farcasterService from '../services/farcaster'
+import { requireAuth } from '../validation/access-control'
 
 const CastReactionBodySchema = t.Object({
   castHash: t.String({ minLength: 3 }),
@@ -42,14 +43,14 @@ function getPagination(query: { cursor?: string; limit?: string }) {
   }
 }
 
-function requireWalletAddress(
+async function requireWalletAddress(
   headers: Record<string, string | undefined>,
-): Address {
-  const address = headers['x-wallet-address'] as Address | undefined
-  if (!address) {
+): Promise<Address> {
+  const authResult = await requireAuth(headers)
+  if (!authResult.success) {
     throw new Error('UNAUTHORIZED')
   }
-  return address
+  return authResult.address
 }
 
 export const feedRoutes = new Elysia({ prefix: '/api/feed' })
@@ -141,7 +142,7 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
     async ({ body, headers, set }) => {
       let address: Address
       try {
-        address = requireWalletAddress(headers)
+        address = await requireWalletAddress(headers)
       } catch {
         set.status = 401
         return {
@@ -192,7 +193,7 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
     async ({ params, headers, set }) => {
       let address: Address
       try {
-        address = requireWalletAddress(headers)
+        address = await requireWalletAddress(headers)
       } catch {
         set.status = 401
         return {
@@ -218,7 +219,7 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
     async ({ body, headers, set }) => {
       let address: Address
       try {
-        address = requireWalletAddress(headers)
+        address = await requireWalletAddress(headers)
       } catch {
         set.status = 401
         return {
@@ -248,7 +249,7 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
     async ({ body, headers, set }) => {
       let address: Address
       try {
-        address = requireWalletAddress(headers)
+        address = await requireWalletAddress(headers)
       } catch {
         set.status = 401
         return {
@@ -278,7 +279,7 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
     async ({ body, headers, set }) => {
       let address: Address
       try {
-        address = requireWalletAddress(headers)
+        address = await requireWalletAddress(headers)
       } catch {
         set.status = 401
         return {
@@ -308,7 +309,7 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
     async ({ body, headers, set }) => {
       let address: Address
       try {
-        address = requireWalletAddress(headers)
+        address = await requireWalletAddress(headers)
       } catch {
         set.status = 401
         return {
@@ -357,7 +358,7 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
     async ({ params, headers, set }) => {
       let address: Address
       try {
-        address = requireWalletAddress(headers)
+        address = await requireWalletAddress(headers)
       } catch {
         set.status = 401
         return {
@@ -383,7 +384,7 @@ export const feedRoutes = new Elysia({ prefix: '/api/feed' })
     async ({ params, headers, set }) => {
       let address: Address
       try {
-        address = requireWalletAddress(headers)
+        address = await requireWalletAddress(headers)
       } catch {
         set.status = 401
         return {

--- a/apps/factory/api/routes/messages.ts
+++ b/apps/factory/api/routes/messages.ts
@@ -7,6 +7,7 @@ import {
   getUser,
   isFarcasterConnected,
 } from '../services/farcaster'
+import { requireAuth } from '../validation/access-control'
 
 const SendMessageBodySchema = t.Object({
   recipientFid: t.Number({ minimum: 1 }),
@@ -25,12 +26,22 @@ const MessagesQuerySchema = t.Object({
   limit: t.Optional(t.String()),
 })
 
+async function getSignedAddress(
+  headers: Record<string, string | undefined>,
+  options?: { skipNonceCheck?: boolean },
+): Promise<Address | null> {
+  const authResult = await requireAuth(headers, options)
+  return authResult.success ? authResult.address : null
+}
+
 export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   // Get all conversations
   .get(
     '/',
     async ({ headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers, {
+        skipNonceCheck: true,
+      })
       if (!address) {
         set.status = 401
         return {
@@ -105,7 +116,9 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .get(
     '/status',
     async ({ headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers, {
+        skipNonceCheck: true,
+      })
       if (!address) {
         set.status = 401
         return {
@@ -150,7 +163,9 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .get(
     '/conversation/:fid',
     async ({ params, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers, {
+        skipNonceCheck: true,
+      })
       if (!address) {
         set.status = 401
         return {
@@ -217,7 +232,9 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .get(
     '/conversation/:fid/messages',
     async ({ params, query, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers, {
+        skipNonceCheck: true,
+      })
       if (!address) {
         set.status = 401
         return {
@@ -277,7 +294,7 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/',
     async ({ body, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers)
       if (!address) {
         set.status = 401
         return {
@@ -331,7 +348,7 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/conversation/:fid/read',
     async ({ params, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers)
       if (!address) {
         set.status = 401
         return {
@@ -357,7 +374,7 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/conversation/:fid/archive',
     async ({ params, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers)
       if (!address) {
         set.status = 401
         return {
@@ -383,7 +400,7 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/conversation/:fid/mute',
     async ({ params, body, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers)
       if (!address) {
         set.status = 401
         return {
@@ -410,7 +427,7 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/reconnect',
     async ({ headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers)
       if (!address) {
         set.status = 401
         return {
@@ -434,7 +451,9 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .get(
     '/encryption-key',
     async ({ headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers, {
+        skipNonceCheck: true,
+      })
       if (!address) {
         set.status = 401
         return {
@@ -458,7 +477,7 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .post(
     '/encryption-key/publish',
     async ({ headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers)
       if (!address) {
         set.status = 401
         return {
@@ -482,7 +501,9 @@ export const messagesRoutes = new Elysia({ prefix: '/api/messages' })
   .get(
     '/search/users',
     async ({ query, headers, set }) => {
-      const address = headers['x-wallet-address'] as Address | undefined
+      const address = await getSignedAddress(headers, {
+        skipNonceCheck: true,
+      })
       if (!address) {
         set.status = 401
         return {

--- a/apps/factory/api/server.ts
+++ b/apps/factory/api/server.ts
@@ -131,6 +131,16 @@ function createApp() {
               `https://jeju.local:${CORE_PORTS.FACTORY.get()}`,
             ],
         credentials: true,
+        allowedHeaders: [
+          'Content-Type',
+          'Authorization',
+          'X-Request-ID',
+          'X-Wallet-Address',
+          'X-Jeju-Address',
+          'X-Jeju-Timestamp',
+          'X-Jeju-Nonce',
+          'X-Jeju-Signature',
+        ],
       }),
     )
     .use(

--- a/apps/factory/api/worker.ts
+++ b/apps/factory/api/worker.ts
@@ -141,6 +141,16 @@ export function createFactoryApp(env?: Partial<FactoryEnv>) {
               getCoreAppUrl('FACTORY'),
             ],
         credentials: true,
+        allowedHeaders: [
+          'Content-Type',
+          'Authorization',
+          'X-Request-ID',
+          'X-Wallet-Address',
+          'X-Jeju-Address',
+          'X-Jeju-Timestamp',
+          'X-Jeju-Nonce',
+          'X-Jeju-Signature',
+        ],
       }),
     )
     .use(

--- a/apps/factory/web/hooks/useFarcaster.ts
+++ b/apps/factory/web/hooks/useFarcaster.ts
@@ -1,6 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useAccount } from 'wagmi'
-import { API_BASE, apiDelete, apiFetch, apiPost, getHeaders } from '../lib/api'
+import { useAccount, useSignMessage } from 'wagmi'
+import {
+  apiDeleteSigned,
+  apiFetch,
+  apiPost,
+  apiPostSigned,
+} from '../lib/api'
 
 export interface FarcasterUser {
   fid: number
@@ -203,11 +208,7 @@ export function useFeed(options?: {
       if (options?.channel) params.set('channel', options.channel)
       if (options?.feedType) params.set('feedType', options.feedType)
       if (options?.fid) params.set('fid', String(options.fid))
-
-      const response = await fetch(`${API_BASE}/api/feed?${params}`, {
-        headers: getHeaders(address),
-      })
-      return response.json()
+      return apiFetch<FeedResponse>(`/api/feed?${params}`, { address })
     },
     staleTime: 30_000,
   })
@@ -249,6 +250,7 @@ export function useTrendingFeed() {
 
 export function usePublishCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
@@ -257,78 +259,110 @@ export function usePublishCast() {
       channelId?: string
       parentHash?: string
       embeds?: Array<{ url: string }>
-    }) => apiPost('/api/feed', params, address),
+    }) =>
+      apiPostSigned('/api/feed', params, address as string, signMessageAsync),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useDeleteCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (castHash: string) =>
-      apiDelete(`/api/feed/${castHash}`, undefined, address),
+      apiDeleteSigned(
+        `/api/feed/${castHash}`,
+        undefined,
+        address as string,
+        signMessageAsync,
+      ),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useLikeCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (params: { castHash: string; castFid: number }) =>
-      apiPost('/api/feed/like', params, address),
+      apiPostSigned(
+        '/api/feed/like',
+        params,
+        address as string,
+        signMessageAsync,
+      ),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useUnlikeCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (params: { castHash: string; castFid: number }) =>
-      apiDelete('/api/feed/like', params, address),
+      apiDeleteSigned(
+        '/api/feed/like',
+        params,
+        address as string,
+        signMessageAsync,
+      ),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useRecastCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (params: { castHash: string; castFid: number }) =>
-      apiPost('/api/feed/recast', params, address),
+      apiPostSigned(
+        '/api/feed/recast',
+        params,
+        address as string,
+        signMessageAsync,
+      ),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useUnrecastCast() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (params: { castHash: string; castFid: number }) =>
-      apiDelete('/api/feed/recast', params, address),
+      apiDeleteSigned(
+        '/api/feed/recast',
+        params,
+        address as string,
+        signMessageAsync,
+      ),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['feed'] }),
   })
 }
 
 export function useFollowUser() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (targetFid: number) => {
-      const response = await fetch(`${API_BASE}/api/feed/follow/${targetFid}`, {
-        method: 'POST',
-        headers: getHeaders(address),
-      })
-      return response.json()
-    },
+    mutationFn: (targetFid: number) =>
+      apiPostSigned(
+        `/api/feed/follow/${targetFid}`,
+        {},
+        address as string,
+        signMessageAsync,
+      ),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ['farcaster', 'user'] }),
   })
@@ -336,16 +370,17 @@ export function useFollowUser() {
 
 export function useUnfollowUser() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (targetFid: number) => {
-      const response = await fetch(`${API_BASE}/api/feed/follow/${targetFid}`, {
-        method: 'DELETE',
-        headers: getHeaders(address),
-      })
-      return response.json()
-    },
+    mutationFn: (targetFid: number) =>
+      apiDeleteSigned(
+        `/api/feed/follow/${targetFid}`,
+        undefined,
+        address as string,
+        signMessageAsync,
+      ),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ['farcaster', 'user'] }),
   })

--- a/apps/factory/web/hooks/useMessages.ts
+++ b/apps/factory/web/hooks/useMessages.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useAccount } from 'wagmi'
-import { API_BASE, apiFetch, apiPost, getHeaders } from '../lib/api'
+import { useAccount, useSignMessage } from 'wagmi'
+import { apiFetchSigned, apiPostSigned } from '../lib/api'
 
 export interface ConversationUser {
   fid: number
@@ -49,6 +49,7 @@ export interface MessagingStatus {
 
 export function useMessagingStatus() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'status', address],
@@ -56,7 +57,11 @@ export function useMessagingStatus() {
       if (!address) {
         return { connected: false, isInitialized: false, unreadCount: 0 }
       }
-      return apiFetch('/api/messages/status', { address })
+      return apiFetchSigned('/api/messages/status', {
+        address,
+        signMessageAsync,
+        cache: true,
+      })
     },
     enabled: !!address,
     refetchInterval: 30_000,
@@ -66,11 +71,16 @@ export function useMessagingStatus() {
 
 export function useConversations() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'conversations', address],
     queryFn: () =>
-      apiFetch<{ conversations: Conversation[] }>('/api/messages', { address }),
+      apiFetchSigned<{ conversations: Conversation[] }>('/api/messages', {
+        address: address as string,
+        signMessageAsync,
+        cache: true,
+      }),
     enabled: !!address,
     staleTime: 30_000,
   })
@@ -78,14 +88,18 @@ export function useConversations() {
 
 export function useConversation(recipientFid: number) {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'conversation', recipientFid, address],
     queryFn: () =>
-      apiFetch<{ conversation: Conversation } | { error: { code: string } }>(
-        `/api/messages/conversation/${recipientFid}`,
-        { address },
-      ),
+      apiFetchSigned<
+        { conversation: Conversation } | { error: { code: string } }
+      >(`/api/messages/conversation/${recipientFid}`, {
+        address: address as string,
+        signMessageAsync,
+        cache: true,
+      }),
     enabled: !!address && !!recipientFid,
     staleTime: 30_000,
   })
@@ -96,6 +110,7 @@ export function useMessages(
   options?: { before?: string; after?: string; limit?: number },
 ) {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'messages', recipientFid, options, address],
@@ -105,11 +120,14 @@ export function useMessages(
       if (options?.after) params.set('after', options.after)
       if (options?.limit) params.set('limit', String(options.limit))
 
-      const response = await fetch(
-        `${API_BASE}/api/messages/conversation/${recipientFid}/messages?${params}`,
-        { headers: getHeaders(address) },
+      return apiFetchSigned<{ messages: Message[] }>(
+        `/api/messages/conversation/${recipientFid}/messages?${params}`,
+        {
+          address: address as string,
+          signMessageAsync,
+          cache: true,
+        },
       )
-      return response.json()
     },
     enabled: !!address && !!recipientFid,
     refetchInterval: 5_000,
@@ -119,6 +137,7 @@ export function useMessages(
 
 export function useSendMessage() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
@@ -127,7 +146,8 @@ export function useSendMessage() {
       text: string
       embeds?: Array<{ url: string }>
       replyTo?: string
-    }) => apiPost('/api/messages', params, address),
+    }) =>
+      apiPostSigned('/api/messages', params, address as string, signMessageAsync),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: ['messages', 'messages', variables.recipientFid],
@@ -140,11 +160,17 @@ export function useSendMessage() {
 
 export function useMarkAsRead() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (recipientFid: number) =>
-      apiPost(`/api/messages/conversation/${recipientFid}/read`, {}, address),
+      apiPostSigned(
+        `/api/messages/conversation/${recipientFid}/read`,
+        {},
+        address as string,
+        signMessageAsync,
+      ),
     onSuccess: (_, recipientFid) => {
       queryClient.invalidateQueries({
         queryKey: ['messages', 'conversation', recipientFid],
@@ -157,14 +183,16 @@ export function useMarkAsRead() {
 
 export function useArchiveConversation() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (recipientFid: number) =>
-      apiPost(
+      apiPostSigned(
         `/api/messages/conversation/${recipientFid}/archive`,
         {},
-        address,
+        address as string,
+        signMessageAsync,
       ),
     onSuccess: () =>
       queryClient.invalidateQueries({
@@ -175,14 +203,16 @@ export function useArchiveConversation() {
 
 export function useMuteConversation() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (params: { recipientFid: number; muted: boolean }) =>
-      apiPost(
+      apiPostSigned(
         `/api/messages/conversation/${params.recipientFid}/mute`,
         { muted: params.muted },
-        address,
+        address as string,
+        signMessageAsync,
       ),
     onSuccess: (_, { recipientFid }) => {
       queryClient.invalidateQueries({
@@ -195,23 +225,35 @@ export function useMuteConversation() {
 
 export function useReconnect() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: () => apiPost('/api/messages/reconnect', {}, address),
+    mutationFn: () =>
+      apiPostSigned(
+        '/api/messages/reconnect',
+        {},
+        address as string,
+        signMessageAsync,
+      ),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['messages'] }),
   })
 }
 
 export function useSearchUsers(query: string) {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'search', query, address],
     queryFn: () =>
-      apiFetch<{ users: ConversationUser[] }>(
+      apiFetchSigned<{ users: ConversationUser[] }>(
         `/api/messages/search/users?q=${encodeURIComponent(query)}`,
-        { address },
+        {
+          address: address as string,
+          signMessageAsync,
+          cache: true,
+        },
       ),
     enabled: !!address && query.length >= 2,
     staleTime: 60_000,
@@ -220,10 +262,16 @@ export function useSearchUsers(query: string) {
 
 export function useEncryptionKey() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
 
   return useQuery({
     queryKey: ['messages', 'encryption-key', address],
-    queryFn: () => apiFetch('/api/messages/encryption-key', { address }),
+    queryFn: () =>
+      apiFetchSigned('/api/messages/encryption-key', {
+        address: address as string,
+        signMessageAsync,
+        cache: true,
+      }),
     enabled: !!address,
     staleTime: 300_000,
   })
@@ -231,11 +279,17 @@ export function useEncryptionKey() {
 
 export function usePublishEncryptionKey() {
   const { address } = useAccount()
+  const { signMessageAsync } = useSignMessage()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: () =>
-      apiPost('/api/messages/encryption-key/publish', {}, address),
+      apiPostSigned(
+        '/api/messages/encryption-key/publish',
+        {},
+        address as string,
+        signMessageAsync,
+      ),
     onSuccess: () =>
       queryClient.invalidateQueries({
         queryKey: ['messages', 'encryption-key'],

--- a/apps/factory/web/lib/api.ts
+++ b/apps/factory/web/lib/api.ts
@@ -8,6 +8,60 @@ import { FACTORY_API_URL } from '../config/env'
 
 export const API_BASE = FACTORY_API_URL
 
+type SignMessageAsync = (args: { message: string }) => Promise<string>
+
+const SIGNED_READ_TTL_MS = 4 * 60 * 1000
+let cachedReadAuth:
+  | {
+      address: string
+      expiresAt: number
+      headers: Record<string, string>
+    }
+  | null = null
+
+function buildAuthMessage(timestamp: number, nonce: string): string {
+  return `Factory Auth\nTimestamp: ${timestamp}\nNonce: ${nonce}`
+}
+
+async function getSignedHeaders(
+  address: string,
+  signMessageAsync: SignMessageAsync,
+  options?: { cache?: boolean },
+): Promise<Record<string, string>> {
+  if (
+    options?.cache &&
+    cachedReadAuth &&
+    cachedReadAuth.address === address &&
+    cachedReadAuth.expiresAt > Date.now()
+  ) {
+    return { ...cachedReadAuth.headers }
+  }
+
+  const timestamp = Date.now()
+  const nonce = crypto.randomUUID()
+  const message = buildAuthMessage(timestamp, nonce)
+  const signature = await signMessageAsync({ message })
+
+  const headers = {
+    'x-jeju-address': address,
+    'x-jeju-timestamp': String(timestamp),
+    'x-jeju-nonce': nonce,
+    'x-jeju-signature': signature,
+    'x-wallet-address': address,
+    authorization: `Bearer ${address}`,
+  }
+
+  if (options?.cache) {
+    cachedReadAuth = {
+      address,
+      expiresAt: Date.now() + SIGNED_READ_TTL_MS,
+      headers,
+    }
+  }
+
+  return headers
+}
+
 /** Build headers with optional wallet address authentication */
 export function getHeaders(address?: string): Record<string, string> {
   const headers: Record<string, string> = {}
@@ -37,6 +91,32 @@ export async function apiFetch<T>(
   return response.json()
 }
 
+/** Signed fetch wrapper with wallet signature authentication */
+export async function apiFetchSigned<T>(
+  path: string,
+  options: RequestInit & {
+    address: string
+    signMessageAsync: SignMessageAsync
+    cache?: boolean
+  },
+): Promise<T> {
+  const { address, signMessageAsync, cache, ...fetchOptions } = options
+  const signedHeaders = await getSignedHeaders(address, signMessageAsync, {
+    cache,
+  })
+  const headers = {
+    ...signedHeaders,
+    ...(fetchOptions.headers as Record<string, string> | undefined),
+  }
+
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...fetchOptions,
+    headers,
+  })
+
+  return response.json()
+}
+
 /** POST request helper */
 export async function apiPost<T>(
   path: string,
@@ -46,6 +126,24 @@ export async function apiPost<T>(
   return apiFetch<T>(path, {
     method: 'POST',
     address,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+/** Signed POST request helper */
+export async function apiPostSigned<T>(
+  path: string,
+  body: unknown,
+  address: string,
+  signMessageAsync: SignMessageAsync,
+  options?: { cache?: boolean },
+): Promise<T> {
+  return apiFetchSigned<T>(path, {
+    method: 'POST',
+    address,
+    signMessageAsync,
+    cache: options?.cache,
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
@@ -66,4 +164,26 @@ export async function apiDelete<T>(
     options.body = JSON.stringify(body)
   }
   return apiFetch<T>(path, options)
+}
+
+/** Signed DELETE request helper */
+export async function apiDeleteSigned<T>(
+  path: string,
+  body: unknown | undefined,
+  address: string,
+  signMessageAsync: SignMessageAsync,
+  options?: { cache?: boolean },
+): Promise<T> {
+  const headers: Record<string, string> = {}
+  if (body) {
+    headers['Content-Type'] = 'application/json'
+  }
+  return apiFetchSigned<T>(path, {
+    method: 'DELETE',
+    address,
+    signMessageAsync,
+    cache: options?.cache,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  })
 }


### PR DESCRIPTION
## Summary\n- enforce signed wallet auth for Factory messages read/write endpoints\n- enforce signed wallet auth for feed write endpoints\n- add signed request helpers + update web hooks to sign messages\n- allow x-jeju-* headers in Factory CORS\n\n## Testing\n- not run (not requested)