### PR TITLE
fix: resolve type incompatibilities across zksolbridge docs server

### DIFF
--- a/apps/documentation/server/a2a-server.ts
+++ b/apps/documentation/server/a2a-server.ts
@@ -1,4 +1,3 @@
-import { cors } from '@elysiajs/cors'
 import {
   CORE_PORTS,
   getLocalhostHost,
@@ -144,6 +143,25 @@ const AGENT_CARD = {
   ],
 } as const
 
+function resolveOrigin(origin?: string | null): string | null {
+  if (!origin) return null
+  return ALLOWED_ORIGINS.includes(origin) ? origin : null
+}
+
+function applyCorsHeaders(
+  set: { headers: Record<string, string | string[] | number> },
+  request: Request,
+) {
+  const allowedOrigin = resolveOrigin(request.headers.get('origin'))
+  if (!allowedOrigin) return
+  set.headers['Access-Control-Allow-Origin'] = allowedOrigin
+  set.headers['Access-Control-Allow-Credentials'] = 'true'
+  set.headers['Access-Control-Allow-Headers'] = 'Content-Type'
+  set.headers['Access-Control-Allow-Methods'] = 'GET,POST,OPTIONS'
+  set.headers['Access-Control-Max-Age'] = '86400'
+  set.headers.Vary = 'Origin'
+}
+
 /** Validate documentation page path (no traversal allowed) */
 function validateDocPath(pagePath: string): string {
   // Normalize and check for path traversal
@@ -204,16 +222,14 @@ async function executeSkill(
 }
 
 export const app = new Elysia()
-  .use(
-    cors({
-      origin: (request) => {
-        const origin = request.headers.get('origin')
-        if (!origin) return true
-        return ALLOWED_ORIGINS.includes(origin)
-      },
-      credentials: true,
-    }),
-  )
+  .onRequest(({ request, set }) => {
+    applyCorsHeaders(set, request)
+    return
+  })
+  .options('*', ({ request, set }) => {
+    applyCorsHeaders(set, request)
+    return new Response(null, { status: 204 })
+  })
   .derive(({ request, server }) => {
     const forwarded = request.headers.get('x-forwarded-for')
     const clientIp =

--- a/apps/documentation/tests/unit/a2a.test.ts
+++ b/apps/documentation/tests/unit/a2a.test.ts
@@ -37,8 +37,8 @@ describe('A2A Server Structure', () => {
 
   test('has proper CORS configuration', async () => {
     const serverCode = await Bun.file(SERVER_PATH).text()
-    expect(serverCode).toContain('cors(')
     expect(serverCode).toContain('ALLOWED_ORIGINS')
+    expect(serverCode).toContain('Access-Control-Allow-Origin')
   })
 })
 

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -12,7 +12,8 @@
       "import": "./dist/index.js"
     },
     "./tee": {
-      "types": "./dist/tee/index.d.ts",
+      "bun": "./src/tee/index.ts",
+      "types": "./src/tee/index.ts",
       "import": "./dist/tee/index.js"
     },
     "./config/*": "./config/*.json"


### PR DESCRIPTION
## Summary
- Export `@jejunetwork/zksolbridge/tee` types from source in workspace environments.
- Replace `@elysiajs/cors` usage in documentation A2A server with local CORS middleware to avoid duplicate `elysia` type mismatch.
- Update A2A unit test to assert explicit CORS headers.

## Validation
- bun run --cwd packages/bridge typecheck
- bun run --cwd apps/documentation typecheck
- bunx pyright packages/training/python apps/dws/api (pre-existing unrelated errors remain)
