### PR TITLE
chore: fix root typecheck command for turbo packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "dev": "bun run jeju dev",
     "build": "bun run jeju build",
     "test": "bun run jeju test",
-    "typecheck": "turbo run typecheck --filter='!./vendor/*' && tsc --noEmit && pyright packages/training/python apps/dws/api && bun run \"typecheck:rust\"",
+    "typecheck": "turbo run typecheck && tsc --noEmit && pyright packages/training/python apps/dws/api && bun run \"typecheck:rust\"",
     "typecheck:rust": "bash -c '. $HOME/.cargo/env 2>/dev/null; mkdir -p apps/node/app/dist apps/vpn/app/dist apps/wallet/app/dist; cargo check --manifest-path apps/node/app/src-tauri/Cargo.toml && cargo check --manifest-path apps/vpn/app/src-tauri/Cargo.toml && cargo check --manifest-path apps/wallet/app/src-tauri/Cargo.toml'",
     "lint": "biome check --write --unsafe packages apps && ruff check packages apps --exclude packages/workerd --exclude packages/contracts/lib --fix && ruff format packages apps --exclude packages/workerd --exclude packages/contracts/lib && bun run \"lint:rust\"",
     "lint:rust": "bash -c '. $HOME/.cargo/env 2>/dev/null; cargo fmt --manifest-path apps/node/app/src-tauri/Cargo.toml && cargo fmt --manifest-path apps/vpn/app/src-tauri/Cargo.toml && cargo fmt --manifest-path apps/wallet/app/src-tauri/Cargo.toml'",


### PR DESCRIPTION
## Summary
- Remove the unsupported `--filter='!./vendor/*'` from the root `typecheck` script so turbo runs across all workspace packages as intended.

## Validation
- bun run --cwd packages/auth typecheck
- bun run --cwd packages/sqlit typecheck
- bun run --cwd apps/wallet typecheck
- bun run --cwd apps/documentation typecheck
- bun run --cwd packages/bridge typecheck
- bun run typecheck:rust
- bunx pyright packages/training/python apps/dws/api (pre-existing unrelated errors remain)
