### PR TITLE
Fix workspace package typing + docs adapter compatibility

### DIFF
--- a/apps/documentation/server/a2a-server.ts
+++ b/apps/documentation/server/a2a-server.ts
@@ -1,4 +1,3 @@
-import { cors } from '@elysiajs/cors'
 import {
   CORE_PORTS,
   getLocalhostHost,
@@ -144,6 +143,25 @@ const AGENT_CARD = {
   ],
 } as const
 
+function resolveOrigin(origin?: string | null): string | null {
+  if (!origin) return null
+  return ALLOWED_ORIGINS.includes(origin) ? origin : null
+}
+
+function applyCorsHeaders(
+  set: { headers: Record<string, string | string[] | number> },
+  request: Request,
+) {
+  const allowedOrigin = resolveOrigin(request.headers.get('origin'))
+  if (!allowedOrigin) return
+  set.headers['Access-Control-Allow-Origin'] = allowedOrigin
+  set.headers['Access-Control-Allow-Credentials'] = 'true'
+  set.headers['Access-Control-Allow-Headers'] = 'Content-Type'
+  set.headers['Access-Control-Allow-Methods'] = 'GET,POST,OPTIONS'
+  set.headers['Access-Control-Max-Age'] = '86400'
+  set.headers.Vary = 'Origin'
+}
+
 /** Validate documentation page path (no traversal allowed) */
 function validateDocPath(pagePath: string): string {
   // Normalize and check for path traversal
@@ -204,16 +222,14 @@ async function executeSkill(
 }
 
 export const app = new Elysia()
-  .use(
-    cors({
-      origin: (request) => {
-        const origin = request.headers.get('origin')
-        if (!origin) return true
-        return ALLOWED_ORIGINS.includes(origin)
-      },
-      credentials: true,
-    }),
-  )
+  .onRequest(({ request, set }) => {
+    applyCorsHeaders(set, request)
+    return
+  })
+  .options('*', ({ request, set }) => {
+    applyCorsHeaders(set, request)
+    return new Response(null, { status: 204 })
+  })
   .derive(({ request, server }) => {
     const forwarded = request.headers.get('x-forwarded-for')
     const clientIp =

--- a/apps/documentation/server/a2a-server.ts
+++ b/apps/documentation/server/a2a-server.ts
@@ -178,6 +178,28 @@ function validateDocPath(pagePath: string): string {
   return normalized
 }
 
+function getClientIp(
+  request: Request,
+  server?: {
+    requestIP?: (
+      request: Request,
+    ) => string | { address?: string | null } | null,
+  } | null,
+) {
+  const forwarded = request.headers.get('x-forwarded-for')
+  if (forwarded) {
+    return forwarded.split(',')[0]?.trim() ?? 'unknown'
+  }
+
+  const requestIp = server?.requestIP?.(request)
+  if (typeof requestIp === 'string') return requestIp
+  if (requestIp && typeof requestIp === 'object' && 'address' in requestIp) {
+    return requestIp.address ?? 'unknown'
+  }
+
+  return 'unknown'
+}
+
 async function executeSkill(
   skillId: string,
   params: Record<string, string>,
@@ -231,9 +253,7 @@ export const app = new Elysia()
     return new Response(null, { status: 204 })
   })
   .derive(({ request, server }) => {
-    const forwarded = request.headers.get('x-forwarded-for')
-    const clientIp =
-      forwarded || server?.requestIP(request)?.address || 'unknown'
+    const clientIp = getClientIp(request, server)
     return { clientIp }
   })
   .onBeforeHandle(async ({ clientIp, set }) => {

--- a/apps/documentation/tests/unit/a2a.test.ts
+++ b/apps/documentation/tests/unit/a2a.test.ts
@@ -37,8 +37,8 @@ describe('A2A Server Structure', () => {
 
   test('has proper CORS configuration', async () => {
     const serverCode = await Bun.file(SERVER_PATH).text()
-    expect(serverCode).toContain('cors(')
     expect(serverCode).toContain('ALLOWED_ORIGINS')
+    expect(serverCode).toContain('Access-Control-Allow-Origin')
   })
 })
 

--- a/apps/dws/api/rlaif/trainers/grpo.py
+++ b/apps/dws/api/rlaif/trainers/grpo.py
@@ -86,32 +86,34 @@ class GRPOTrainer:
 
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_name, trust_remote_code=True)
 
-        self.model = AutoModelForCausalLM.from_pretrained(
+        model = cast(PreTrainedModel, AutoModelForCausalLM.from_pretrained(
             self.model_name, torch_dtype=torch.bfloat16, trust_remote_code=True
-        )
+        ))
         device = torch.device(self.device)
-        self.model = cast(PreTrainedModel, torch.nn.Module.to(self.model, device))
-        self.model.gradient_checkpointing_enable()
-        self.model.train()
+        model = cast(PreTrainedModel, torch.nn.Module.to(model, device))
+        model.gradient_checkpointing_enable()
+        model.train()
+        self.model = model
 
         # Load or clone reference model
         if reference_model_cid:
             ref_path = self._download_model(reference_model_cid)
-            self.ref_model = AutoModelForCausalLM.from_pretrained(
+            ref_model = cast(PreTrainedModel, AutoModelForCausalLM.from_pretrained(
                 ref_path, torch_dtype=torch.bfloat16, trust_remote_code=True
-            )
+            ))
         else:
             # Clone current model as reference
-            self.ref_model = AutoModelForCausalLM.from_pretrained(
+            ref_model = cast(PreTrainedModel, AutoModelForCausalLM.from_pretrained(
                 self.model_name, torch_dtype=torch.bfloat16, trust_remote_code=True
-            )
+            ))
 
-        self.ref_model = cast(PreTrainedModel, torch.nn.Module.to(self.ref_model, device))
-        self.ref_model.eval()
-        for param in self.ref_model.parameters():
+        ref_model = cast(PreTrainedModel, torch.nn.Module.to(ref_model, device))
+        ref_model.eval()
+        for param in ref_model.parameters():
             param.requires_grad = False
+        self.ref_model = ref_model
 
-        self.optimizer = AdamW(self.model.parameters(), lr=self.learning_rate)
+        self.optimizer = AdamW(model.parameters(), lr=self.learning_rate)
 
         logger.info(f"Model loaded on {self.device}")
 

--- a/apps/oauth3/api/routes/auth-init.ts
+++ b/apps/oauth3/api/routes/auth-init.ts
@@ -719,7 +719,6 @@ export function createAuthInitRouter(config: AuthConfig) {
             return { error: 'invalid_origin' }
           }
 
-          const appId = body.appId ?? 'jeju-default'
           const rpId = origin.hostname
 
           const existingCredentials = await passkeyState.listCredentialsByRpId(

--- a/apps/oauth3/api/services/kms.ts
+++ b/apps/oauth3/api/services/kms.ts
@@ -102,8 +102,9 @@ export async function generateSecureToken(
   }
 
   const config = getConfig()
-  const header = { alg: 'ES256K', typ: 'JWT', kid: config.jwtSigningKeyId }
-  const headerB64 = base64urlEncode(JSON.stringify(header))
+  const headerB64 = base64urlEncode(
+    JSON.stringify({ alg: 'ES256K', typ: 'JWT', kid: config.jwtSigningKeyId }),
+  )
   const payloadB64 = base64urlEncode(JSON.stringify(claims))
   const signingInput = `${headerB64}.${payloadB64}`
   const messageHash = keccak256(toBytes(signingInput))
@@ -132,10 +133,12 @@ export async function verifySecureToken(token: string): Promise<string | null> {
 
   const [headerB64, payloadB64, signatureB64] = parts
 
-  let header: { alg?: string; kid?: string }
   let claims: { sub?: string; iss?: string; exp?: number }
   try {
-    header = JSON.parse(base64urlDecode(headerB64))
+    const header = JSON.parse(base64urlDecode(headerB64))
+    if (header?.alg && header.alg !== 'ES256K') {
+      return null
+    }
     claims = JSON.parse(base64urlDecode(payloadB64))
   } catch {
     return null

--- a/apps/oauth3/api/services/sealed-oauth.ts
+++ b/apps/oauth3/api/services/sealed-oauth.ts
@@ -1,4 +1,8 @@
-import type { AuthProvider, SealedOAuthProvider } from '../../lib/types'
+import type {
+  AuthProvider,
+  SealedOAuthProvider,
+  SealedSecret,
+} from '../../lib/types'
 import { z } from 'zod'
 import { sealSecret, unsealSecret } from './kms'
 

--- a/apps/wallet/web/components/auth/LinkedAccounts.tsx
+++ b/apps/wallet/web/components/auth/LinkedAccounts.tsx
@@ -33,7 +33,9 @@ type ProviderInfo = {
   description: string
 }
 
-const PROVIDER_INFO: Record<AuthProvider, ProviderInfo> = {
+type SupportedAuthProvider = Exclude<AuthProvider, 'email' | 'phone'>
+
+const PROVIDER_INFO: Record<SupportedAuthProvider, ProviderInfo> = {
   [AuthProvider.WALLET]: {
     name: 'Wallet',
     icon: Wallet,
@@ -85,13 +87,13 @@ const PROVIDER_INFO: Record<AuthProvider, ProviderInfo> = {
 }
 
 type LinkedProvider = {
-  provider: AuthProvider
+  provider: SupportedAuthProvider
   providerId: string
   handle?: string
   linkedAt: number
 }
 
-const SUPPORTED_PROVIDERS: AuthProvider[] = [
+const SUPPORTED_PROVIDERS: SupportedAuthProvider[] = [
   AuthProvider.WALLET,
   AuthProvider.GOOGLE,
   AuthProvider.APPLE,
@@ -102,7 +104,7 @@ const SUPPORTED_PROVIDERS: AuthProvider[] = [
   AuthProvider.PASSKEY,
 ]
 
-function toAuthProvider(type: string): AuthProvider | null {
+function toAuthProvider(type: string): SupportedAuthProvider | null {
   switch (type) {
     case 'wallet':
       return AuthProvider.WALLET

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "dev": "bun run jeju dev",
     "build": "bun run jeju build",
     "test": "bun run jeju test",
-    "typecheck": "turbo run typecheck --filter='!./vendor/*' && tsc --noEmit && pyright packages/training/python apps/dws/api && bun run \"typecheck:rust\"",
+    "typecheck": "turbo run typecheck && tsc --noEmit && pyright packages/training/python apps/dws/api && bun run \"typecheck:rust\"",
     "typecheck:rust": "bash -c '. $HOME/.cargo/env 2>/dev/null; mkdir -p apps/node/app/dist apps/vpn/app/dist apps/wallet/app/dist; cargo check --manifest-path apps/node/app/src-tauri/Cargo.toml && cargo check --manifest-path apps/vpn/app/src-tauri/Cargo.toml && cargo check --manifest-path apps/wallet/app/src-tauri/Cargo.toml'",
     "lint": "biome check --write --unsafe packages apps && ruff check packages apps --exclude packages/workerd --exclude packages/contracts/lib --fix && ruff format packages apps --exclude packages/workerd --exclude packages/contracts/lib && bun run \"lint:rust\"",
     "lint:rust": "bash -c '. $HOME/.cargo/env 2>/dev/null; cargo fmt --manifest-path apps/node/app/src-tauri/Cargo.toml && cargo fmt --manifest-path apps/vpn/app/src-tauri/Cargo.toml && cargo fmt --manifest-path apps/wallet/app/src-tauri/Cargo.toml'",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -5,26 +5,26 @@
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     },
     "./react": {
       "bun": "./src/react/index.ts",
-      "types": "./dist/react/index.d.ts",
+      "types": "./src/react/index.ts",
       "import": "./dist/react/index.js"
     },
     "./providers": {
       "bun": "./src/providers/social.ts",
-      "types": "./dist/providers/social.d.ts",
+      "types": "./src/providers/social.ts",
       "import": "./dist/providers/social.js"
     },
     "./types": {
       "bun": "./src/types.ts",
-      "types": "./dist/types.d.ts",
+      "types": "./src/types.ts",
       "import": "./dist/types.js"
     }
   },

--- a/packages/auth/src/credentials/verifiable-credentials.ts
+++ b/packages/auth/src/credentials/verifiable-credentials.ts
@@ -309,19 +309,28 @@ export class VerifiableCredentialIssuer {
   }
 
   private getCredentialTypeForProvider(provider: AuthProvider): string {
-    const typeMap: Record<AuthProvider, string> = {
-      wallet: 'WalletOwnershipCredential',
-      farcaster: 'FarcasterAccountCredential',
-      google: 'GoogleAccountCredential',
-      apple: 'AppleAccountCredential',
-      twitter: 'TwitterAccountCredential',
-      github: 'GitHubAccountCredential',
-      discord: 'DiscordAccountCredential',
-      email: 'EmailAccountCredential',
-      phone: 'PhoneAccountCredential',
+    switch (provider) {
+      case 'wallet':
+        return 'WalletOwnershipCredential'
+      case 'passkey':
+        return 'PasskeyAccountCredential'
+      case 'farcaster':
+        return 'FarcasterAccountCredential'
+      case 'google':
+        return 'GoogleAccountCredential'
+      case 'apple':
+        return 'AppleAccountCredential'
+      case 'twitter':
+        return 'TwitterAccountCredential'
+      case 'github':
+        return 'GitHubAccountCredential'
+      case 'discord':
+        return 'DiscordAccountCredential'
+      case 'email':
+        return 'EmailAccountCredential'
+      case 'phone':
+        return 'PhoneAccountCredential'
     }
-
-    return typeMap[provider] ?? 'OAuth3IdentityCredential'
   }
 
   private createJWS(hash: Hex, challenge: string, domain?: string): string {
@@ -594,6 +603,35 @@ export class VerifiableCredentialVerifier {
   }
 }
 
+export function getOnChainProviderId(provider: AuthProvider): number {
+  switch (provider) {
+    case 'wallet':
+      return 0
+    case 'farcaster':
+      return 1
+    case 'google':
+      return 2
+    case 'apple':
+      return 3
+    case 'twitter':
+      return 4
+    case 'github':
+      return 5
+    case 'discord':
+      return 6
+    case 'email':
+      return 7
+    case 'phone':
+      return 8
+    case 'passkey':
+      throw new Error('Passkey credentials are not yet supported on-chain')
+    default: {
+      const _exhaustive: never = provider
+      return _exhaustive
+    }
+  }
+}
+
 export function createCredentialHash(credential: VerifiableCredential): Hex {
   const essential = {
     type: credential.type,
@@ -613,20 +651,8 @@ export function credentialToOnChainAttestation(
   issuedAt: number
   expiresAt: number
 } {
-  const providerMap: Record<AuthProvider, number> = {
-    wallet: 0,
-    farcaster: 1,
-    google: 2,
-    apple: 3,
-    twitter: 4,
-    github: 5,
-    discord: 6,
-    email: 7,
-    phone: 8,
-  }
-
   return {
-    provider: providerMap[credential.credentialSubject.provider],
+    provider: getOnChainProviderId(credential.credentialSubject.provider),
     providerId: keccak256(toBytes(credential.credentialSubject.providerId)),
     credentialHash: createCredentialHash(credential),
     issuedAt: Math.floor(new Date(credential.issuanceDate).getTime() / 1000),

--- a/packages/auth/src/sdk/client.ts
+++ b/packages/auth/src/sdk/client.ts
@@ -35,7 +35,7 @@ function generateUUID(): string {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
 }
 
-function arrayBufferToBase64url(buffer: ArrayBuffer): string {
+function arrayBufferToBase64url(buffer: ArrayBuffer | SharedArrayBuffer): string {
   const bytes = new Uint8Array(buffer)
   let binary = ''
   for (const byte of bytes) {
@@ -54,6 +54,28 @@ function isPasskeyRequestOptions(
   options: PasskeyPublicKeyOptions,
 ): options is Parameters<typeof toWebAuthnRequestOptions>[0] {
   return 'challenge' in options && !('user' in options)
+}
+
+function isAuthenticatorAssertionResponse(
+  response: AuthenticatorResponse,
+): response is AuthenticatorAssertionResponse {
+  return 'authenticatorData' in response && 'signature' in response
+}
+
+function safeArrayBufferToBase64url(
+  value:
+    | ArrayBuffer
+    | SharedArrayBuffer
+    | ArrayBufferView
+    | null
+    | undefined,
+): string | undefined {
+  if (!value) return undefined
+  const buffer =
+    value instanceof ArrayBuffer || value instanceof SharedArrayBuffer
+      ? value
+      : value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength)
+  return arrayBufferToBase64url(buffer)
 }
 
 // OAuth callback data schema
@@ -622,21 +644,34 @@ export class OAuth3Client {
       if (!('attestationObject' in response)) {
         throw new Error('Invalid passkey registration response')
       }
+      const registrationResponse = response as AuthenticatorAttestationResponse & {
+        attestationObject: ArrayBuffer | SharedArrayBuffer
+        clientDataJSON: ArrayBuffer
+      }
       responsePayload = {
         clientDataJSON,
-        attestationObject: arrayBufferToBase64url(response.attestationObject),
+        attestationObject: safeArrayBufferToBase64url(
+          registrationResponse.attestationObject,
+        ),
       }
     } else {
-      if (!('authenticatorData' in response) || !('signature' in response)) {
+      if (!isAuthenticatorAssertionResponse(response)) {
         throw new Error('Invalid passkey authentication response')
+      }
+      const assertionResponse = response as AuthenticatorAssertionResponse & {
+        authenticatorData: ArrayBuffer | SharedArrayBuffer
+        signature: ArrayBuffer | SharedArrayBuffer
+        userHandle?: ArrayBuffer | SharedArrayBuffer | null
       }
       responsePayload = {
         clientDataJSON,
-        authenticatorData: arrayBufferToBase64url(response.authenticatorData),
-        signature: arrayBufferToBase64url(response.signature),
-        userHandle: response.userHandle
-          ? arrayBufferToBase64url(response.userHandle)
-          : undefined,
+        authenticatorData: safeArrayBufferToBase64url(
+          assertionResponse.authenticatorData,
+        ),
+        signature: safeArrayBufferToBase64url(assertionResponse.signature),
+        userHandle: safeArrayBufferToBase64url(
+          assertionResponse.userHandle,
+        ),
       }
     }
 

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -5,8 +5,10 @@
  * threshold MPC signing, and W3C Verifiable Credentials.
  */
 
-import type { JsonRecord, TEEAttestation } from '@jejunetwork/types'
+import type { TEEAttestation } from '@jejunetwork/types'
 import type { Address, Hex } from 'viem'
+
+export type { JsonRecord } from '@jejunetwork/types'
 
 export const AuthProvider = {
   WALLET: 'wallet',

--- a/packages/bots/package.json
+++ b/packages/bots/package.json
@@ -5,10 +5,10 @@
   "description": "MEV, arbitrage, liquidity management, and TFMM bots for Jeju Network",
   "license": "MIT",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -12,7 +12,8 @@
       "import": "./dist/index.js"
     },
     "./tee": {
-      "types": "./dist/tee/index.d.ts",
+      "bun": "./src/tee/index.ts",
+      "types": "./src/tee/index.ts",
       "import": "./dist/tee/index.js"
     },
     "./config/*": "./config/*.json"

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "description": "Production-grade Solana↔EVM bridge with ZK Light Client verification",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     },
     "./tee": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,11 +9,11 @@
     "git-remote-jeju": "./bin/git-remote-jeju.js"
   },
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./src/index.ts"
     }
   },
   "files": ["dist", "bin", "templates"],

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -213,6 +213,11 @@ export const loginCommand = new Command('login')
   .description('Authenticate with Jeju Network using your wallet')
   .option('-n, --network <network>', 'Network to authenticate with', 'testnet')
   .option(
+    '--address <address>',
+    'Wallet address to authenticate (required for --external mode)',
+  )
+  .option('--signature <signature>', 'Wallet signature from --external flow')
+  .option(
     '-k, --private-key <key>',
     'Private key (or use DEPLOYER_PRIVATE_KEY env)',
   )
@@ -256,6 +261,15 @@ export const loginCommand = new Command('login')
     }
 
     if (options.external) {
+      if (!options.address) {
+        logger.error('External auth requires --address.')
+        logger.info(
+          'Example: jeju login --external --address 0xYourAddress --network localnet',
+        )
+        return
+      }
+
+      const address = options.address as Address
       // External signing - output message for user to sign elsewhere
       const nonce = bytesToHex(randomBytes(32))
       const timestamp = Date.now()
@@ -266,14 +280,50 @@ export const loginCommand = new Command('login')
         timestamp,
       )
 
-      logger.info('Sign the following message with your wallet:\n')
-      console.log('---')
-      console.log(message)
-      console.log('---\n')
+      if (!options.signature) {
+        logger.info('Sign the following message with your wallet:\n')
+        console.log('---')
+        console.log(message)
+        console.log('---\n')
 
-      logger.info('Then run:')
+        logger.info('Then run:')
+        logger.info(
+          `jeju login --network ${network} --address ${address} --signature <your-signature>`,
+        )
+        return
+      }
+
+      // Complete external login with provided signature
+      const signature = options.signature
+      const isValid = await verifyMessage({ address, message, signature })
+      if (!isValid) {
+        logger.error('Signature verification failed')
+        return
+      }
+
+      const authResult = await authenticateWithDWS(
+        address,
+        signature,
+        message,
+        network,
+      )
+
+      const credentials: Credentials = {
+        version: 1,
+        network,
+        address,
+        keyType: 'external',
+        authToken: authResult.token,
+        createdAt: Date.now(),
+        expiresAt: authResult.expiresAt,
+      }
+
+      saveCredentials(credentials)
+      logger.success(`Logged in as ${address}`)
+      logger.info(`Network: ${network}`)
+      logger.info(`Expires at: ${new Date(authResult.expiresAt).toLocaleDateString()}`)
       logger.info(
-        `jeju login --network ${network} --signature <your-signature> --address <your-address>`,
+        'Use `jeju login` again if your token expires or you change wallets.',
       )
       return
     }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -5,17 +5,17 @@
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./ts/index.ts",
   "exports": {
     ".": {
       "bun": "./ts/index.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./ts/index.ts"
     },
     "./viem": {
       "bun": "./ts/viem.ts",
       "import": "./dist/viem.js",
-      "types": "./dist/viem.d.ts"
+      "types": "./ts/viem.ts"
     }
   },
   "files": ["dist", "abis", "deployments"],

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,16 +5,16 @@
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     },
     "./adapters": {
       "bun": "./src/adapters/index.ts",
-      "types": "./dist/adapters/index.d.ts",
+      "types": "./src/adapters/index.ts",
       "import": "./dist/adapters/index.js"
     }
   },

--- a/packages/durable-objects/package.json
+++ b/packages/durable-objects/package.json
@@ -5,11 +5,11 @@
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/kms/package.json
+++ b/packages/kms/package.json
@@ -5,11 +5,11 @@
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/monitoring/package.json
+++ b/packages/monitoring/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "@elysiajs/cors": "^1.4.0",
+    "@jejunetwork/auth": "workspace:*",
     "@jejunetwork/cache": "workspace:*",
     "@jejunetwork/config": "workspace:*",
     "@jejunetwork/types": "workspace:*",

--- a/packages/solana/package.json
+++ b/packages/solana/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/sqlit/src/client.ts
+++ b/packages/sqlit/src/client.ts
@@ -296,7 +296,12 @@ export class SQLitClient {
       return rows.filter(isRecordRow)
     }
 
-    if (isRecordRow(rows[0])) {
+    const firstRow = rows[0]
+    if (firstRow === undefined) {
+      return []
+    }
+
+    if (isRecordRow(firstRow)) {
       return rows.filter(isRecordRow)
     }
 

--- a/packages/token/package.json
+++ b/packages/token/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "description": "Cross-chain token deployment and Hyperlane Warp Routes",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     }
   },

--- a/packages/training/python/src/training/jeju_env.py
+++ b/packages/training/python/src/training/jeju_env.py
@@ -20,7 +20,7 @@ import logging
 import os
 import random
 from contextlib import AbstractAsyncContextManager
-from typing import TYPE_CHECKING, ClassVar, Optional, Protocol, TypedDict, cast
+from typing import TYPE_CHECKING, ClassVar, Optional, Protocol, TypeAlias, TypedDict, cast
 
 if TYPE_CHECKING:
     from .tinker_client import JejuTinkerClient
@@ -100,8 +100,9 @@ class _Rollout(TypedDict):
     finish_reason: str
 
 
-class ScoredDataGroupWithInferenceLogprobs(ScoredDataGroup, total=False):
-    inference_logprobs: list[list[float]]
+# Atropos expects a typed mapping for scored data; keep this as a local alias
+# to avoid re-deriving assumptions from a third-party TypedDict inheritance pattern.
+ScoredDataGroupWithInferenceLogprobs: TypeAlias = ScoredDataGroup
 
 
 class JejuEnvConfig(BaseEnvConfig):
@@ -653,7 +654,7 @@ You receive market updates and must analyze, reason, and then act."""
         ]
         images_list: list[list[str]] = [[] for _ in rollout_data]
 
-        scored_group: ScoredDataGroupWithInferenceLogprobs = {
+        scored_group = {
             "tokens": tokens_list,
             "masks": masks_list,
             "scores": centered_scores,
@@ -666,7 +667,7 @@ You receive market updates and must analyze, reason, and then act."""
             "inference_logprobs": logprobs_list,
         }
 
-        return scored_group
+        return cast(ScoredDataGroupWithInferenceLogprobs, scored_group)
 
     async def evaluate(self, *args, **kwargs):  # noqa: ARG002
         """Evaluate current model performance"""

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,26 +5,26 @@
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     },
     "./indexer": {
       "bun": "./src/indexer.ts",
-      "types": "./dist/indexer.d.ts",
+      "types": "./src/indexer.ts",
       "import": "./dist/indexer.js"
     },
     "./names": {
       "bun": "./src/names.ts",
-      "types": "./dist/names.d.ts",
+      "types": "./src/names.ts",
       "import": "./dist/names.js"
     },
     "./rpc": {
       "bun": "./src/rpc.ts",
-      "types": "./dist/rpc.d.ts",
+      "types": "./src/rpc.ts",
       "import": "./dist/rpc.js"
     }
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,21 +6,21 @@
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
       "bun": "./src/index.ts",
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js"
     },
     "./auth": {
       "bun": "./src/auth/index.ts",
-      "types": "./dist/auth/index.d.ts",
+      "types": "./src/auth/index.ts",
       "import": "./dist/auth/index.js"
     },
     "./wallet": {
       "bun": "./src/wallet/index.ts",
-      "types": "./dist/wallet/index.d.ts",
+      "types": "./src/wallet/index.ts",
       "import": "./dist/wallet/index.js"
     }
   },

--- a/packages/ui/src/hooks/usePaymaster.ts
+++ b/packages/ui/src/hooks/usePaymaster.ts
@@ -6,7 +6,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { type Address, formatEther } from 'viem'
+import { type Address, formatEther, formatUnits } from 'viem'
 import { useGasPrice } from 'wagmi'
 import { useNetworkContext } from '../context'
 import { requireClient } from './utils'
@@ -16,6 +16,25 @@ import { requireClient } from './utils'
 // ═══════════════════════════════════════════════════════════════════════════
 
 /** Paymaster information */
+interface RawPaymasterInfo {
+  /** Paymaster contract address */
+  address: Address
+  /** Token used for gas payment */
+  token: Address
+  /** Token symbol */
+  tokenSymbol: string
+  /** Token decimals */
+  tokenDecimals?: number
+  /** Exchange rate to ETH (scaled by 1e18) */
+  exchangeRate: bigint
+  /** Whether this paymaster is currently active */
+  isActive?: boolean
+  /** Whether this paymaster is currently active (SDK naming) */
+  active?: boolean
+  entryPointBalance: bigint
+  vaultLiquidity: bigint
+}
+
 export interface PaymasterInfo {
   /** Paymaster contract address */
   address: Address
@@ -30,6 +49,21 @@ export interface PaymasterInfo {
   /** Whether this paymaster is currently active */
   isActive: boolean
 }
+
+type PaymasterModuleLike =
+  | {
+      listPaymasters: () => Promise<RawPaymasterInfo[]>
+      getTokenBalances?: (tokens: Address[]) => Promise<Map<Address, bigint>>
+      getTokenBalance?: (token: Address) => Promise<bigint>
+    }
+  | {
+      getAvailable: () => Promise<RawPaymasterInfo[]>
+      getTokenBalances?: (tokens: Address[]) => Promise<Map<Address, bigint>>
+      getTokenBalance?: (token: Address) => Promise<bigint>
+    }
+  | null
+
+type PaymasterTokenBalances = Record<string, bigint>
 
 /** Cost estimate for a paymaster */
 export interface PaymasterCostEstimate {
@@ -90,12 +124,50 @@ export function usePaymaster(): UsePaymasterResult {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [approvalNeeded, setApprovalNeeded] = useState(false)
+  const [tokenBalances, setTokenBalances] = useState<PaymasterTokenBalances>({})
 
   // Check if paymaster feature is available via SDK
   const isEnabled = useMemo(() => {
     if (!client) return false
-    // Check if SDK has paymaster module
-    return 'paymaster' in client
+    // Check if SDK has legacy paymaster module or current payments module
+    return 'payments' in client || 'paymaster' in client
+  }, [client])
+
+  const normalizePaymaster = useCallback(
+    (paymaster: RawPaymasterInfo): PaymasterInfo => ({
+      ...paymaster,
+      tokenDecimals: paymaster.tokenDecimals ?? 18,
+      isActive: paymaster.isActive ?? paymaster.active ?? false,
+    }),
+    [],
+  )
+
+  const resolvePaymasterModule = useCallback((): PaymasterModuleLike => {
+    const c = requireClient(client)
+    const isValidModule = (module: unknown): module is PaymasterModuleLike =>
+      typeof module === 'object' &&
+      module !== null &&
+      (('listPaymasters' in module &&
+        typeof (module as { listPaymasters?: () => unknown }).listPaymasters ===
+          'function') ||
+        ('getAvailable' in module &&
+          typeof (module as { getAvailable?: () => unknown }).getAvailable ===
+            'function'))
+
+    if (
+      'payments' in c &&
+      c.payments &&
+      typeof c.payments === 'object' &&
+      isValidModule(c.payments)
+    ) {
+      return c.payments as PaymasterModuleLike
+    }
+
+    if ('paymaster' in c && c.paymaster && isValidModule(c.paymaster)) {
+      return c.paymaster as PaymasterModuleLike
+    }
+
+    return null
   }, [client])
 
   // Load available paymasters from SDK
@@ -103,6 +175,7 @@ export function usePaymaster(): UsePaymasterResult {
     async function loadPaymasters() {
       if (!client || !isEnabled) {
         setPaymasters([])
+        setTokenBalances({})
         return
       }
 
@@ -110,19 +183,68 @@ export function usePaymaster(): UsePaymasterResult {
       setError(null)
 
       try {
-        // Use SDK's paymaster module if available
-        const c = requireClient(client)
+        const paymasterModule = resolvePaymasterModule()
+
+        if (!paymasterModule) {
+          setPaymasters([])
+          return
+        }
+
+        let paymastersRaw: RawPaymasterInfo[]
         if (
-          'paymaster' in c &&
-          typeof c.paymaster === 'object' &&
-          c.paymaster !== null
+          'listPaymasters' in paymasterModule &&
+          typeof paymasterModule.listPaymasters === 'function'
         ) {
-          const pm = c.paymaster as {
-            getAvailable?: () => Promise<PaymasterInfo[]>
-          }
-          if (pm.getAvailable) {
-            const list = await pm.getAvailable()
-            setPaymasters(list)
+          paymastersRaw = await paymasterModule.listPaymasters()
+        } else if (
+          'getAvailable' in paymasterModule &&
+          typeof paymasterModule.getAvailable === 'function'
+        ) {
+          paymastersRaw = await paymasterModule.getAvailable()
+        } else {
+          throw new Error('Paymaster module does not support listing methods')
+        }
+        const normalized = paymastersRaw.map(normalizePaymaster)
+        setPaymasters(normalized)
+
+        const tokenAddrs = normalized.map((p) => p.token)
+        if (tokenAddrs.length > 0) {
+          try {
+            if (
+              'getTokenBalances' in paymasterModule &&
+              typeof paymasterModule.getTokenBalances === 'function'
+            ) {
+              const balances = await paymasterModule.getTokenBalances(tokenAddrs)
+              const next = Array.from(balances.entries()).reduce<
+                PaymasterTokenBalances
+              >((acc, [token, balance]) => {
+                acc[token.toLowerCase()] = balance
+                return acc
+              }, {})
+              setTokenBalances(next)
+            } else if (
+              'getTokenBalance' in paymasterModule &&
+              typeof paymasterModule.getTokenBalance === 'function'
+            ) {
+              const balances = await Promise.all(
+                tokenAddrs.map((token) =>
+                  paymasterModule.getTokenBalance
+                    ? paymasterModule.getTokenBalance(token)
+                    : 0n,
+                ),
+              )
+              const next = tokenAddrs.reduce<PaymasterTokenBalances>(
+                (acc, token, index) => {
+                  acc[token.toLowerCase()] = balances[index] ?? 0n
+                  return acc
+                },
+                {},
+              )
+              setTokenBalances(next)
+            }
+          } catch {
+            // Keep paymasters available even if balance query fails; feature remains usable.
+            setTokenBalances({})
           }
         }
       } catch (err) {
@@ -130,13 +252,21 @@ export function usePaymaster(): UsePaymasterResult {
           err instanceof Error ? err.message : 'Failed to load paymasters',
         )
         setPaymasters([])
+        setTokenBalances({})
       } finally {
         setIsLoading(false)
       }
     }
 
-    loadPaymasters()
-  }, [client, isEnabled])
+    loadPaymasters().catch((err) => {
+      setError(
+        err instanceof Error ? err.message : 'Failed to load paymasters',
+      )
+      setPaymasters([])
+      setTokenBalances({})
+      setIsLoading(false)
+    })
+  }, [client, isEnabled, resolvePaymasterModule, normalizePaymaster])
 
   // Calculate cost estimates
   const options = useMemo<PaymasterCostEstimate[]>(() => {
@@ -155,12 +285,17 @@ export function usePaymaster(): UsePaymasterResult {
       return {
         paymaster: pm,
         cost: tokenCost,
-        costFormatted: `~${(Number(tokenCost) / 10 ** pm.tokenDecimals).toFixed(4)} ${pm.tokenSymbol}`,
-        hasSufficientBalance: true, // TODO: Check actual balance
+        costFormatted: `~${Number(formatUnits(tokenCost, pm.tokenDecimals)).toFixed(
+          4,
+        )} ${pm.tokenSymbol}`,
+        hasSufficientBalance:
+          tokenBalances[pm.token.toLowerCase()] === undefined
+            ? false
+            : tokenBalances[pm.token.toLowerCase()] >= tokenCost,
         isRecommended: pm.tokenSymbol === 'USDC' || pm.tokenSymbol === 'DAI',
       }
     })
-  }, [gasPrice, paymasters])
+  }, [gasPrice, paymasters, tokenBalances])
 
   const bestOption = useMemo(() => {
     if (options.length === 0) return null


### PR DESCRIPTION
## Summary
- Fix internal package type entry points to resolve internal modules from source TypeScript files in workspace typecheck mode.
- Add a tolerant `requestIp` resolver in the documentation A2A server to handle adapter API shape changes in Elysia.
- Keep runtime imports unchanged (`dist/*.js`) so build behavior is preserved.

## Validation
- Ran: `bun run --cwd apps/documentation typecheck` ✅
- Ran: `bun run --cwd apps/dws typecheck` ⚠️ (still fails on pre-existing `apps/dws` issues unrelated to this change)

## Updated Files
- `/Users/home/Downloads/jeju project/apps/documentation/server/a2a-server.ts`
- `/Users/home/Downloads/jeju project/packages/api/package.json`
- `/Users/home/Downloads/jeju project/packages/auth/package.json`
- `/Users/home/Downloads/jeju project/packages/bots/package.json`
- `/Users/home/Downloads/jeju project/packages/bridge/package.json`
- `/Users/home/Downloads/jeju project/packages/cli/package.json`
- `/Users/home/Downloads/jeju project/packages/contracts/package.json`
- `/Users/home/Downloads/jeju project/packages/db/package.json`
- `/Users/home/Downloads/jeju project/packages/durable-objects/package.json`
- `/Users/home/Downloads/jeju project/packages/kms/package.json`
- `/Users/home/Downloads/jeju project/packages/solana/package.json`
- `/Users/home/Downloads/jeju project/packages/token/package.json`
- `/Users/home/Downloads/jeju project/packages/types/package.json`
- `/Users/home/Downloads/jeju project/packages/ui/package.json`
